### PR TITLE
Add detach parameter to add_action()

### DIFF
--- a/async_hooks/manager.py
+++ b/async_hooks/manager.py
@@ -86,6 +86,7 @@ class AsyncHooks:
         callback: CallbackType,
         priority: int = 10,
         timeout_seconds: Optional[float] = None,
+        detach: bool = False,
     ) -> str:
         """Register an action callback.
 


### PR DESCRIPTION
## Summary

- Adds `detach: bool = False` parameter to `AsyncHooks.add_action()`
- Unblocks consumers (e.g. [PAOP/persistence](https://github.com/danieliser/persistence)) that pass `detach=True` when registering heartbeat cycle hooks

Currently the parameter is accepted but not yet implemented — this is the minimum change to unblock the `TypeError` on startup.

## Context

`persistence`'s `cycle_hooks.py` registers actions with `detach=True`:
```python
hooks.add_action("heartbeat.cycle_start", _recover_locks, priority=10, detach=True)
```

This causes a `TypeError` since `add_action()` doesn't accept that kwarg.